### PR TITLE
Fix NPCs using template will be blackface

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,3 +35,7 @@
 .Trashes
 ehthumbs.db
 Thumbs.db
+
+# Ignore Folders #
+##################
+backup\


### PR DESCRIPTION
テンプレートを利用しているNPCがガングロ化する可能性があったので修正しました。
修正内容

- Facegenファイルが存在しない場合を検出するフラグ変数を追加
- このフラグを参照して、Facegenファイルが存在しない場合はSkypatcher iniファイルに設定を追記しないように変更
- 将来的にはテンプレートを参照している場合とそうでない場合でメッセージを表示させてわかりやすくしたい

ついでにgitignoreファイルを編集