### PR TITLE
Code refactoring

### DIFF
--- a/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
+++ b/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
@@ -2,7 +2,8 @@ unit NPCRC_CommonUtils;
 
 interface
 
-function ShowCheckboxForm(const options, checkedOpts, disableOpts: TStringList; var selected: TStringList; caption: string): Boolean;
+function mmskStrToBool(s: string): Boolean;
+function ShowCheckboxForm(const options, disableOpts: TStringList; caption: string): Boolean;
 function FormIDInputValidation(const s: string): Boolean;
 function EditorIDInputValidation(const s: string; useUnderScore: boolean): Boolean;
 function RemoveLeadingZeros(const s: string): string;
@@ -10,20 +11,28 @@ function FindRecordByRecordID(const recordID, signature: string; useFormID: bool
 
 implementation
 
-function ShowCheckboxForm((const options, checkedOpts, disableOpts: TStringList; var selected: TStringList; caption: string): Boolean;
+function mmskStrToBool(s: string): Boolean;
+begin
+  s := LowerCase(Trim(s));
+  if (s = 'true') or (s = '1') or (s = 'yes') then
+    Result := True
+  else
+    Result := False;
+end;
+
+function ShowCheckboxForm(const options, disableOpts: TStringList; caption: string): Boolean;
 var
   form: TForm;
   checklist: TCheckListBox;
   btnOK, btnCancel: TButton;
   i: Integer;
-  shouldCheck, shouldDisable: Boolean;
+  shouldDisable: Boolean;
 begin
   Result := False;
 
   // デバッグ: 入力内容を確認
 {  AddMessage('=== Debug Info ===');
   AddMessage('Options count: ' + IntToStr(options.Count));
-  AddMessage('CheckedOpts count: ' + IntToStr(checkedOpts.Count));
   AddMessage('DisableOpts count: ' + IntToStr(disableOpts.Count));
 }  
   form := TForm.Create(nil);
@@ -39,19 +48,15 @@ begin
     checklist.Height := 200;
 
     for i := 0 to options.Count - 1 do begin
-      checklist.Items.Add(options[i]);
+      checklist.Items.Add(options.ValueFromIndex[i]);
       
-      shouldCheck := false;
       shouldDisable := false;
       
-      // このオプションをチェックすべきか判定
-      shouldCheck := (checkedOpts.Count > 0) and (checkedOpts.IndexOf(options[i]) >= 0);
-      
       // このオプションを無効化すべきか判定
-      shouldDisable := (disableOpts.Count > 0) and (disableOpts.IndexOf(options[i]) >= 0);
+      shouldDisable := (disableOpts.Count > 0) and (disableOpts.IndexOf(options.ValueFromIndex[i]) >= 0);
       
       // デバッグ: 各項目の判定結果
-{      AddMessage('Item ' + IntToStr(i) + ': ' + options[i]);
+{      AddMessage('Item ' + IntToStr(i) + ': ' + options.ValueFromIndex[i]);
       
       if shouldCheck then
         AddMessage('  shouldCheck: True')
@@ -64,8 +69,8 @@ begin
         AddMessage('  shouldDisable: False');
 }
       
-      // 
-      if shouldCheck then
+      // このオプションをチェックすべきか判定
+      if mmskStrToBool(options.ValueFromIndex[i]) then
         checklist.Checked[i] := true;
       
       // 注意：ItemEnabledはtrue:無効化、false:有効化となる
@@ -101,9 +106,9 @@ begin
       Result := True;
       for i := 0 to checklist.Items.Count - 1 do
         if checklist.Checked[i] then
-          selected.Add('True')
+          options.ValueFromIndex[i] := 'True'
         else
-          selected.Add('False');
+          options.ValueFromIndex[i] := 'False';
     end;
   finally
     form.Free;

--- a/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
+++ b/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
@@ -2,7 +2,7 @@ unit NPCRC_CommonUtils;
 
 interface
 
-function mmskStrToBool(s: string): Boolean;
+function GetBoolSLValue(const key: string): Boolean;
 function ShowCheckboxForm(const options, disableOpts: TStringList; caption: string): Boolean;
 function FormIDInputValidation(const s: string): Boolean;
 function EditorIDInputValidation(const s: string; useUnderScore: boolean): Boolean;
@@ -11,13 +11,12 @@ function FindRecordByRecordID(const recordID, signature: string; useFormID: bool
 
 implementation
 
-function mmskStrToBool(s: string): Boolean;
+function GetBoolSLValue(const s: string): Boolean;
+var
+  value: string;
 begin
-  s := LowerCase(Trim(s));
-  if (s = 'true') or (s = '1') or (s = 'yes') then
-    Result := True
-  else
-    Result := False;
+  value := LowerCase(s);
+  Result := (value = 'true') or (value = '1') or (value = 'yes');
 end;
 
 function ShowCheckboxForm(const options, disableOpts: TStringList; caption: string): Boolean;
@@ -48,12 +47,12 @@ begin
     checklist.Height := 200;
 
     for i := 0 to options.Count - 1 do begin
-      checklist.Items.Add(options.ValueFromIndex[i]);
+      checklist.Items.Add(options.Names[i]);
       
       shouldDisable := false;
       
       // このオプションを無効化すべきか判定
-      shouldDisable := (disableOpts.Count > 0) and (disableOpts.IndexOf(options.ValueFromIndex[i]) >= 0);
+      shouldDisable := (disableOpts.Count > 0) and (disableOpts.IndexOf(options.Names[i]) >= 0);
       
       // デバッグ: 各項目の判定結果
 {      AddMessage('Item ' + IntToStr(i) + ': ' + options.ValueFromIndex[i]);
@@ -70,7 +69,7 @@ begin
 }
       
       // このオプションをチェックすべきか判定
-      if mmskStrToBool(options.ValueFromIndex[i]) then
+      if GetBoolSLValue(options.ValueFromIndex[i]) then
         checklist.Checked[i] := true;
       
       // 注意：ItemEnabledはtrue:無効化、false:有効化となる

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -34,8 +34,8 @@
       - Compatible with both FormID- and EditorID-based reference methods.
 
    Author:mmsk4989
-   Version: 2.0
-   Last Updated: [2025-10-04]
+   Version: 2.1.2
+   Last Updated: [2025-11-15]
   ==============================================================================
 }
 

--- a/SP_RDF NPC Replacer Converter - PreProcessor.pas
+++ b/SP_RDF NPC Replacer Converter - PreProcessor.pas
@@ -27,8 +27,8 @@
      - Dependent on standard xEdit functions; no external libraries required.
 
    Author:mmsk4989
-   Version: 2.0
-   Last Updated: [2025-10-04]
+   Version: 2.1.2
+   Last Updated: [2025-11-15]
   ==============================================================================
 }
 
@@ -249,7 +249,7 @@ end;
 function DoInitialize: integer;
 var
   validInput : boolean;
-  opts, checkedOpts, disableOpts, selected: TStringList;
+  opts, disableOpts: TStringList;
   checkBoxCaption: string;
   i: Integer;
 begin
@@ -276,9 +276,7 @@ begin
   missingFaceGenBothRecordID  := TStringList.Create;
   
   opts                := TStringList.Create;
-  checkedOpts         := TStringList.Create;
   disableOpts         := TStringList.Create;
-  selected            := TStringList.Create;
   
   checkBoxCaption             := 'Choose PreProcessor Option';
   
@@ -288,14 +286,14 @@ begin
   // 各オプションの設定
   try
 
-    opts.Add('Remove FaceGen files in the replacer mod');
-    opts.Add('Remove NPC records without FaceGen files');
+    opts.Values['Remove FaceGen files in the replacer mod'] := 'False';
+    opts.Values['Remove NPC records without FaceGen files'] := 'False';
 
-    if ShowCheckboxForm(opts, checkedOpts, disableOpts, selected, checkBoxCaption) then
+    if ShowCheckboxForm(opts, disableOpts, checkBoxCaption) then
     begin
       AddMessage('You selected:');
-      for i := 0 to selected.Count - 1 do
-        AddMessage(opts[i] + ' - ' + selected[i]);
+      for i := 0 to opts.Count - 1 do
+        AddMessage(opts.Names[i] + ' - ' + opts.ValueFromIndex[i]);
     end
     else begin
       AddMessage('Selection was canceled.');
@@ -305,18 +303,14 @@ begin
     
 
     // コピー元のFaceGenファイルを残すか
-    if selected[0] = 'True' then
-      removeFaceGen := true;
+    removeFaceGen := GetBoolSLValue(opts.Values['Remove FaceGen files in the replacer mod']);
     
     // FaceGenファイルを持たないNPCレコードをコピーするか
-    if selected[1] = 'True' then
-      removeFaceGenMissingRec := true;
+    removeFaceGenMissingRec := GetBoolSLValue(opts.Values['Remove NPC records without FaceGen files']);
       
   finally
     opts.Free;
-    checkedOpts.Free;
     disableOpts.Free;
-    selected.Free;
   end;
 
   // プレフィックスを入力


### PR DESCRIPTION
コードリファクタリング
主な修正点

- TStringList型をName=Value形式で使う方法が分かったので実装してみた
- Name:オプション名、Value:Bool値文字列（True, False）というやり方をオプション選択に適用させてみた

CommonUtils

- ShowCheckboxFormの内部処理を変更、必要な引数を4→2に減らした
- GetBoolSLValue関数を追加。TStringList型ではBool値を文字列で格納しているので変換する関数があると便利
- 標準環境ではStrToBoolが使えるらしいけどxEditでは使えないので簡易版を独自実装

PreProcessor

- ShowCheckboxForm関連の処理を変更

ConfigGenerator

- ShowCheckboxForm関連の処理を変更
- CommentOut変数をslCommentOutにまとめて、変数を削減
- 処理を見直して、各要素の比較フラグ変数を削除
- slExportに格納する文字列生成に使う変数の接頭辞をslからexportに変更
-（StreamLineだと思ってたけど多分コレStringListだわ）