### PR TITLE
Improve summary

### DIFF
--- a/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
+++ b/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
@@ -19,6 +19,43 @@ begin
   Result := (value = 'true') or (value = '1') or (value = 'yes');
 end;
 
+function CreateSLValueFromRecordID(const formID, editorID: string): string;
+begin
+  Result := 'FormID=' + formID + ';EditorID=' + editorID + ';';
+end;
+
+function CreateSLValueFromRecordIDWithName(const formID, editorID, npcName: string): string;
+begin
+  Result := 'FormID=' + formID + ';EditorID=' + editorID + ';Name=' + npcName + ';';
+end;
+
+function ExtractStringListValue(const valueString: string; const key: string): string;
+var
+  searchStr: string;
+  startPos, endPos: Integer;
+begin
+  Result := '';
+  
+  // "Key="形式で検索
+  searchStr := key + '=';
+  startPos := Pos(searchStr, valueString);
+  
+  if startPos = 0 then Exit;
+  
+  // 値の開始位置
+  startPos := startPos + Length(searchStr);
+  
+  // 次の;を探す（値の終わり）
+  endPos := Pos(';', Copy(valueString, startPos, Length(valueString)));
+  
+  if endPos > 0 then
+    // ;が見つかった場合、そこまでを取得
+    Result := Copy(valueString, startPos, endPos - 1)
+  else
+    // ;が見つからない場合、最後まで取得
+    Result := Copy(valueString, startPos, Length(valueString));
+end;
+
 function ShowCheckboxForm(const options, disableOpts: TStringList; caption: string): Boolean;
 var
   form: TForm;

--- a/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
+++ b/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
@@ -8,6 +8,8 @@ function FormIDInputValidation(const s: string): Boolean;
 function EditorIDInputValidation(const s: string; useUnderScore: boolean): Boolean;
 function RemoveLeadingZeros(const s: string): string;
 function FindRecordByRecordID(const recordID, signature: string; useFormID: boolean): IwbMainRecord;
+function CreateSLValueFromRecordID(const editorID, formID, fileName: string): string;
+function ExtractStringListValue(const valueString: string; const key: string): string;
 
 implementation
 
@@ -19,14 +21,11 @@ begin
   Result := (value = 'true') or (value = '1') or (value = 'yes');
 end;
 
-function CreateSLValueFromRecordID(const formID, editorID: string): string;
+function CreateSLValueFromRecordID(const editorID, formID, fileName: string): string;
 begin
-  Result := 'FormID=' + formID + ';EditorID=' + editorID + ';';
-end;
-
-function CreateSLValueFromRecordIDWithName(const formID, editorID, npcName: string): string;
-begin
-  Result := 'FormID=' + formID + ';EditorID=' + editorID + ';Name=' + npcName + ';';
+  // EditorIDをName、FormIDとFileNameをValueとして登録
+  // 各値の読み出しはExtractStringListValue関数を利用する
+  Result := editorID + '=FormID=' + formID + ';FileName=' + fileName;
 end;
 
 function ExtractStringListValue(const valueString: string; const key: string): string;

--- a/SP_RDF NPC Replacer Converter - PreProcessor.pas
+++ b/SP_RDF NPC Replacer Converter - PreProcessor.pas
@@ -73,9 +73,9 @@ var
   missingFaceTintCount, missingFaceGenBothCount,
   useTraitsCount, removedRecordCount: integer;
   
-  missingFaceGeomRecordID,
-  missingFaceTintRecordID,
-  missingFaceGenBothRecordID: TStringList;
+  slMissingFaceGeomRecordID,
+  slMissingFaceTintRecordID,
+  slMissingFaceGenBothRecordID: TStringList;
 
 function IsMasterAEPlugin(plugin: IInterface): Boolean;
 var
@@ -356,9 +356,9 @@ begin
   useTraitsCount              := 0;
   removedRecordCount          := 0;
   
-  missingFaceGeomRecordID     := TStringList.Create;
-  missingFaceTintRecordID     := TStringList.Create;
-  missingFaceGenBothRecordID  := TStringList.Create;
+  slMissingFaceGeomRecordID     := TStringList.Create;
+  slMissingFaceTintRecordID     := TStringList.Create;
+  slMissingFaceGenBothRecordID  := TStringList.Create;
   
   slOpts                := TStringList.Create;
   slDisableOpts         := TStringList.Create;
@@ -569,12 +569,12 @@ begin
       AddMessage('This record (' + recordID + ') uses a template and has the Use Traits flag, so it''s normal that it doesn''t have FaceGen files.');
       AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
       Inc(useTraitsCount);
-      missingFaceGenBothRecordID.Add(recordID + ' (with UseTraits flag)');
+      slMissingFaceGenBothRecordID.Add(recordID + ' (with UseTraits flag)');
     end
     else begin
       AddMessage('This record (' + recordID + ') should have FaceGen files, but none were found.');
       AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
-      missingFaceGenBothRecordID.Add(recordFileName + ' ' + recordID);
+      slMissingFaceGenBothRecordID.Add(recordFileName + ' ' + recordID);
       Exit;
     end;
   end
@@ -583,7 +583,7 @@ begin
     AddMessage('FaceGeom file associated with this record (' + recordID + ') is missing.');
     AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
     Inc(missingFaceGeomCount);
-    missingFaceGeomRecordID.Add(recordFileName + ' ' + recordID);
+    slMissingFaceGeomRecordID.Add(recordFileName + ' ' + recordID);
     Exit;
   end
   else if not missingFacegeom and missingFacetint then begin
@@ -591,7 +591,7 @@ begin
     AddMessage('FaceTint file associated with this record (' + recordID + ') is missing.');
     AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
     Inc(missingFaceTintCount);
-    missingFaceTintRecordID.Add(recordFileName + ' ' + recordID);
+    slMissingFaceTintRecordID.Add(recordFileName + ' ' + recordID);
     Exit;
   end;
   
@@ -644,22 +644,22 @@ begin
   
   AddMessage(#13#10 + 'Records Missing Both FaceGen Files: ' + IntToStr(missingFaceGenBothCount));
   AddMessage(' (with UseTraits Flag): ' + IntToStr(useTraitsCount));
-  for i := 0 to missingFaceGenBothRecordID.Count - 1 do
-    AddMessage(missingFaceGenBothRecordID[i]);
+  for i := 0 to slMissingFaceGenBothRecordID.Count - 1 do
+    AddMessage(slMissingFaceGenBothRecordID[i]);
     
   AddMessage(#13#10 + 'Records Missing FaceGeom File: ' + IntToStr(missingFaceGeomCount));
-  for i := 0 to missingFaceGeomRecordID.Count - 1 do
-    AddMessage(missingFaceGeomRecordID[i]);
+  for i := 0 to slMissingFaceGeomRecordID.Count - 1 do
+    AddMessage(slMissingFaceGeomRecordID[i]);
     
   AddMessage(#13#10 + 'Records Missing FaceTint File: ' + IntToStr(missingFaceTintCount));
-  for i := 0 to missingFaceTintRecordID.Count - 1 do
-    AddMessage(missingFaceTintRecordID[i]);
+  for i := 0 to slMissingFaceTintRecordID.Count - 1 do
+    AddMessage(slMissingFaceTintRecordID[i]);
     
   AddMessage(#13#10 + '------------------------------PreProcessing Summary End------------------------------');
   
-  missingFaceGeomRecordID.Free;
-  missingFaceTintRecordID.Free;
-  missingFaceGenBothRecordID.Free;
+  slMissingFaceGeomRecordID.Free;
+  slMissingFaceTintRecordID.Free;
+  slMissingFaceGenBothRecordID.Free;
 end;
 
 function RunPreProcInitialize: integer;


### PR DESCRIPTION
PreProcessorのサマリー表示を改善
ファイル名ごとにFormIDとEditorIDを簡易的な表形式で表示するようにした。
また、共通スクリプトにStringList用の関数を二つ追加。
value内でkey=value形式を作ってデータを格納しているので、keyと区切り文字を指定すれば任意の値を取り出せる。
この方法はいろいろと応用が利きそう。