### PR TITLE
improve UseTraits Exclusion Message

### DIFF
--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -282,7 +282,9 @@ begin
   useTraits := GetElementNativeValues(templateFlags, 'Use Traits') <> 0;
   
   if useTraits then begin
+    AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
     AddMessage('This NPC Record has Use Traits Template Flag. Config generation will be skipped.');
+    AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
     Exit;
   end;
   


### PR DESCRIPTION
ConfigGeneratorのメッセージ表示を改善。
UseTraitsフラグ持ちを除外したことを知らせるメッセージを強調させた。