### PR TITLE
Add outfit option

### DIFF
--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -41,6 +41,7 @@
      - Changed Force Replace XXX option behavior:
        When OFF: Do not output the setting line
        When ON: Output the setting line with comparison logic (same as before)
+     - Added Outfit setting output option
   ==============================================================================
 }
 
@@ -164,6 +165,7 @@ begin
       disableOpts.Add('Output Gender setting');
       disableOpts.Add('Output Name setting');
       disableOpts.Add('Output VoiceType setting');
+      disableOpts.Add('Output Outfit setting');
     end;
 
     if ShowCheckboxForm(opts, disableOpts, checkBoxCaption) then

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -60,8 +60,8 @@ var
   // イニシャル処理で設定・使用する変数
   callPreProcessor, useSkyPatcher, useFormID, disableAll, replaceVS, replaceSkin: boolean;
 
-  // Force Replace フラグ - ONの場合のみ該当の設定行を出力する
-  outputRace, outputGender, outputName, outputVoiceType: boolean;
+  // Output setting フラグ - ONの場合のみ該当の設定行を出力する
+  outputRace, outputGender, outputName, outputVoiceType, outputOutfit: boolean;
 
 function GenerateVisualStyleString(const targetID, replacerID: string; useSkyPatcher: boolean): string;
 begin
@@ -91,12 +91,12 @@ begin
   replaceVS           := false;
   replaceSkin         := false;
 
-  // Force Replace オプションのデフォルト値を設定
+  // Output setting オプションのデフォルト値を設定
   outputRace          := false;
   outputGender        := false;
   outputName          := false;
   outputVoiceType     := false;
-
+  outputOutfit        := false;
   opts                := TStringList.Create;
   disableOpts         := TStringList.Create;
 
@@ -132,6 +132,7 @@ begin
   slCommentOut.Values['Gender']    := '';
   slCommentOut.Values['Name']      := '';
   slCommentOut.Values['VoiceType'] := '';
+  slCommentOut.Values['Outfit']    := '';
 
   if useSkyPatcher then
     checkBoxCaption := 'Choose SkyPatcher Option'
@@ -151,7 +152,7 @@ begin
     opts.Values['Output Gender setting']              := 'False';
     opts.Values['Output Name setting']                := 'False';
     opts.Values['Output VoiceType setting']           := 'False';
-
+    opts.Values['Output Outfit setting']              := 'False';
     if useSkyPatcher then begin
       opts.Values['Replace Visual Style'] := 'True';
       opts.Values['Replace Skin']         := 'True';
@@ -192,7 +193,7 @@ begin
     outputGender    := GetBoolSLValue(opts.Values['Output Gender setting']);
     outputName      := GetBoolSLValue(opts.Values['Output Name setting']);
     outputVoiceType := GetBoolSLValue(opts.Values['Output VoiceType setting']);
-
+    outputOutfit    := GetBoolSLValue(opts.Values['Output Outfit setting']);
     // オプションの選択に応じて、設定行をコメントアウトする
     if disableAll then begin
       slCommentOut.Values['CopyVS']    := coChar;
@@ -201,6 +202,7 @@ begin
       slCommentOut.Values['Gender']    := coChar;
       slCommentOut.Values['Name']      := coChar;
       slCommentOut.Values['VoiceType'] := coChar;
+      slCommentOut.Values['Outfit']    := coChar;
     end
     else begin
       if useSkyPatcher and not replaceVS then
@@ -223,12 +225,12 @@ end;
 function Process(e: IInterface): integer;
 
 var
-  replacerFlags, templateFlags, replacerRaceElement, replacerVoiceTypeElement, targetFlags, targetRaceElement, targetVoiceTypeElement: IInterface;
-  replacerRecord, targetRecord, replacerRaceRecord, replacerVoiceTypeRecord, targetRaceRecord, targetVoiceTypeRecord: IwbMainRecord;
+  replacerFlags, templateFlags, replacerRaceElement, replacerVoiceTypeElement, replacerOutfitElement, targetFlags, targetRaceElement, targetVoiceTypeElement, targetOutfitElement: IInterface;
+  replacerRecord, targetRecord, replacerRaceRecord, replacerVoiceTypeRecord, replacerOutfitRecord, targetRaceRecord, targetVoiceTypeRecord, targetOutfitRecord: IwbMainRecord;
   replacerName, targetName: string;
   replacerFormID, underscorePos: Cardinal;
   originalTargetID, recordSignature, targetFormID, targetEditorID, replacerEditorID: string; // レコードID関連
-  trimedTargetFormID, trimedReplacerFormID, exportTargetID, exportReplacerID, wnamID, exportSkinID, exportRace, exportGender, exportName, exportVoiceType: string; // SkyPatcher iniファイルの記入用
+  trimedTargetFormID, trimedReplacerFormID, exportTargetID, exportReplacerID, wnamID, exportSkinID, exportRace, exportGender, exportName, exportVoiceType, exportOutfit: string; // SkyPatcher iniファイルの記入用
   useTraits: boolean;
 begin
   targetFormID    := '';
@@ -286,6 +288,8 @@ begin
   replacerName             := GetElementEditValues(replacerRecord, 'FULL');
   replacerVoiceTypeElement := ElementByPath(replacerRecord, 'VTCK');
   replacerVoiceTypeRecord  := MasterOrSelf(LinksTo(replacerVoiceTypeElement));
+  replacerOutfitElement    := ElementByPath(replacerRecord, 'DOFT');
+  replacerOutfitRecord     := MasterOrSelf(LinksTo(replacerOutfitElement));
 
   // レコードがuse traitsフラグを持っているか確認し、持っていた場合はスキップ
   templateFlags := ElementByPath(replacerFlags, 'Template Flags');
@@ -305,6 +309,8 @@ begin
   targetName             := GetElementEditValues(targetRecord, 'FULL');
   targetVoiceTypeElement := ElementByPath(targetRecord, 'VTCK');
   targetVoiceTypeRecord  := MasterOrSelf(LinksTo(targetVoiceTypeElement));
+  targetOutfitElement    := ElementByPath(targetRecord, 'DOFT');
+  targetOutfitRecord     := MasterOrSelf(LinksTo(targetOutfitElement));
 
   // 各設定行の出力が有効かつdisableAllがOFFの場合のみ、比較判定を行う
   // disableAllがONの場合は、Initializeで既に全てコメントアウトに設定済みなので何もしない
@@ -337,6 +343,13 @@ begin
       if GetElementNativeValues(replacerVoiceTypeRecord, 'Record Header\FormID') = GetElementNativeValues(targetVoiceTypeRecord, 'Record Header\FormID') then
         slCommentOut.Values['VoiceType'] := coChar;
     end;
+
+    if outputOutfit then begin
+      slCommentOut.Values['Outfit'] := '';
+      // 出力が同じ場合はコメントアウト
+      if GetElementNativeValues(replacerOutfitRecord, 'Record Header\FormID') = GetElementNativeValues(targetOutfitRecord, 'Record Header\FormID') then
+        slCommentOut.Values['Outfit'] := coChar;
+    end;
   end;
 
   // 出力ファイル用の配列操作
@@ -362,12 +375,14 @@ begin
 
     exportRace  := GetFileName(replacerRaceRecord) + '|' + IntToHex(FormID(replacerRaceRecord) and  $FFFFFF, 1);
     exportVoiceType := GetFileName(replacerVoiceTypeRecord) + '|' + IntToHex(FormID(replacerVoiceTypeRecord) and  $FFFFFF, 1);
+    exportOutfit := GetFileName(replacerOutfitRecord) + '|' + IntToHex(FormID(replacerOutfitRecord) and  $FFFFFF, 1);
   end
   else begin
     exportTargetID := targetEditorID;
     exportReplacerID := replacerEditorID;
     exportRace  := EditorID(replacerRaceRecord);
     exportVoiceType := EditorID(replacerVoiceTypeRecord);
+    exportOutfit := EditorID(replacerOutfitRecord);
   end;
 
   // NPCレコードのWNAMフィールドが設定されていたらWNAMのスキンを反映。
@@ -407,6 +422,9 @@ begin
 
     if outputVoiceType then
       slExport.Add(slCommentOut.Values['VoiceType'] + 'filterByNpcs=' + exportTargetID + ':voiceType=' + exportVoiceType);
+
+    if outputOutfit then
+      slExport.Add(slCommentOut.Values['Outfit'] + 'filterByNpcs=' + exportTargetID + ':outfitDefault=' + exportOutfit);
   end;
 
   slExport.Add(#13#10);

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -34,8 +34,13 @@
       - Compatible with both FormID- and EditorID-based reference methods.
 
    Author:mmsk4989
-   Version: 2.1.2
-   Last Updated: [2025-11-15]
+   Version: 2.3.0
+   Last Updated: [2026-05-03]
+
+   Changelog:
+     - Changed Force Replace XXX option behavior:
+       When OFF: Do not output the setting line
+       When ON: Output the setting line with comparison logic (same as before)
   ==============================================================================
 }
 
@@ -51,9 +56,12 @@ var
   // 設定ファイル出力用変数
   slExport, slCommentOut: TStringList;
   coChar, targetFileName, replacerFileName: string;
-  
+
   // イニシャル処理で設定・使用する変数
-  callPreProcessor, useSkyPatcher, useFormID, disableAll, replaceVS, replaceSkin, forceEnableRace, forceEnableGender, forceEnableName, forceEnableVoiceType, dontOutputName: boolean;
+  callPreProcessor, useSkyPatcher, useFormID, disableAll, replaceVS, replaceSkin: boolean;
+
+  // Force Replace フラグ - ONの場合のみ該当の設定行を出力する
+  outputRace, outputGender, outputName, outputVoiceType: boolean;
 
 function GenerateVisualStyleString(const targetID, replacerID: string; useSkyPatcher: boolean): string;
 begin
@@ -78,31 +86,31 @@ begin
   callPreProcessor    := false;
   useSkyPatcher       := false;
   useFormID           := false;
-  
+
   disableAll          := false;
   replaceVS           := false;
   replaceSkin         := false;
-  
-  forceEnableRace         := false;
-  forceEnableGender       := false;
-  forceEnableName         := false;
-  forceEnableVoiceType    := false;
-  dontOutputName          := false;
-  
+
+  // Force Replace オプションのデフォルト値を設定
+  outputRace          := false;
+  outputGender        := false;
+  outputName          := false;
+  outputVoiceType     := false;
+
   opts                := TStringList.Create;
   disableOpts         := TStringList.Create;
-  
+
   checkBoxCaption := '';
-  
+
   Result              := 0;
-  
+
   if MessageDlg(
     'Run in Integration Mode?' + #13#10 +
     'Yes = Run with PreProcessor' + #13#10 +
     'No = Run ConfigGenerator only', mtConfirmation, [mbYes, mbNo], 0
     ) = mrYes then
     callPreProcessor := true;
-    
+
   if MessageDlg(
     'Select which config file to generate:' + #13#10 +
     'Yes = Generate for SkyPatcher' + #13#10 +
@@ -110,13 +118,13 @@ begin
     mtConfirmation, [mbYes, mbNo], 0
     ) = mrYes then
     useSkyPatcher := true;
-  
+
   // SkyPatcherかRDFの利用に応じてコメントアウト文字を切り替え
   if useSkyPatcher then
     coChar := ';'
   else
     coChar := '#';
-  
+
   //コメントアウト文字列リストの初期化
   slCommentOut.Values['CopyVS']    := '';
   slCommentOut.Values['Skin']      := '';
@@ -124,27 +132,26 @@ begin
   slCommentOut.Values['Gender']    := '';
   slCommentOut.Values['Name']      := '';
   slCommentOut.Values['VoiceType'] := '';
-  
+
   if useSkyPatcher then
     checkBoxCaption := 'Choose SkyPatcher Option'
   else
     checkBoxCaption := 'Choose RDF Option';
-  
+
   if callPreProcessor then
     Result := RunPreProcInitialize;
-    
+
   // 各オプションの設定
   try
     opts.Values['Use Form ID for config file output'] := 'False';
     opts.Values['Disable the config file by default'] := 'False';
     opts.Values['Replace Visual Style']               := 'False';
     opts.Values['Replace Skin']                       := 'False';
-    opts.Values['Force replace Race']                 := 'False';
-    opts.Values['Force replace Gender']               := 'False';
-    opts.Values['Force replace Name']                 := 'False';
-    opts.Values['Force replace VoiceType']            := 'False';
-    opts.Values['Do not output name settings']        := 'False';
-    
+    opts.Values['Output Race setting']                := 'False';
+    opts.Values['Output Gender setting']              := 'False';
+    opts.Values['Output Name setting']                := 'False';
+    opts.Values['Output VoiceType setting']           := 'False';
+
     if useSkyPatcher then begin
       opts.Values['Replace Visual Style'] := 'True';
       opts.Values['Replace Skin']         := 'True';
@@ -152,11 +159,10 @@ begin
     else begin
       disableOpts.Add('Replace Visual Style');
       disableOpts.Add('Replace Skin');
-      disableOpts.Add('Force replace Race');
-      disableOpts.Add('Force replace Gender');
-      disableOpts.Add('Force replace Name');
-      disableOpts.Add('Force replace VoiceType');
-      disableOpts.Add('Do not output name settings');
+      disableOpts.Add('Output Race setting');
+      disableOpts.Add('Output Gender setting');
+      disableOpts.Add('Output Name setting');
+      disableOpts.Add('Output VoiceType setting');
     end;
 
     if ShowCheckboxForm(opts, disableOpts, checkBoxCaption) then
@@ -170,22 +176,23 @@ begin
       Result := -1;
       Exit;
     end;
-    
+
     // 出力ファイルに使うのはFormIDとEditorIDのどちらか
     useFormID := GetBoolSLValue(opts.Values['Use Form ID for config file output']);
-    
+
     // 出力ファイルの記述をすべてコメントアウトするか
     disableAll := GetBoolSLValue(opts.Values['Disable the config file by default']);
-    
+
     // SkyPatcher利用時のオプション設定
-    replaceVS            := GetBoolSLValue(opts.Values['Replace Visual Style']);    // 見た目を変更するか
-    replaceSkin          := GetBoolSLValue(opts.Values['Replace Skin']);            // 肌を変更するか
-    forceEnableRace      := GetBoolSLValue(opts.Values['Force replace Race']);      // 種族を強制的に変更するか
-    forceEnableGender    := GetBoolSLValue(opts.Values['Force replace Gender']);    // 性別を強制的に変更するか
-    forceEnableName      := GetBoolSLValue(opts.Values['Force replace Name']);      // 名前を強制的に変更するか
-    forceEnableVoiceType := GetBoolSLValue(opts.Values['Force replace VoiceType']); // 音声タイプを強制的に変更するか
-    dontOutputName       := GetBoolSLValue(opts.Values['Do not output name settings']); // 名前を変更する設定行を出力させない
-    
+    replaceVS       := GetBoolSLValue(opts.Values['Replace Visual Style']);    // 見た目を変更するか
+    replaceSkin     := GetBoolSLValue(opts.Values['Replace Skin']);            // 肌を変更するか
+
+    // 各設定行を出力するかどうか（ONの場合のみ出力）
+    outputRace      := GetBoolSLValue(opts.Values['Output Race setting']);
+    outputGender    := GetBoolSLValue(opts.Values['Output Gender setting']);
+    outputName      := GetBoolSLValue(opts.Values['Output Name setting']);
+    outputVoiceType := GetBoolSLValue(opts.Values['Output VoiceType setting']);
+
     // オプションの選択に応じて、設定行をコメントアウトする
     if disableAll then begin
       slCommentOut.Values['CopyVS']    := coChar;
@@ -198,11 +205,14 @@ begin
     else begin
       if useSkyPatcher and not replaceVS then
         slCommentOut.Values['CopyVS'] := coChar;
-        
+
       if not replaceSkin then
         slCommentOut.Values['Skin'] := coChar;
+
+      // outputXXXがOFFの項目は、Processで比較判定を行わないため、
+      // ここで初期化する必要はない（Processで出力自体がスキップされる）
     end;
-  
+
   finally
     opts.Free;
     disableOpts.Free;
@@ -223,38 +233,38 @@ var
 begin
   targetFormID    := '';
   targetEditorID  := '';
-  
+
   recordSignature := 'NPC_';
-  
+
 
   // NPCレコードでなければスキップ
   if Signature(e) <> 'NPC_' then begin
     AddMessage(GetElementEditValues(e, 'EDID') + ' is not NPC record.');
     Exit;
   end;
-  
+
   // リプレイサーMod名を取得
   replacerFileName := GetFileName(GetFile(e));
-  
+
   if callPreProcessor then
     Result := RunPreProcessor(e, replacerRecord)
   else
     replacerRecord := e;
-  
+
   // リプレイサーNPCのForm ID, Editor IDを取得
   replacerFormID := GetElementNativeValues(replacerRecord, 'Record Header\FormID');
    //AddMessage('Replacer Form ID: ' + IntToStr(replacerFormID));
    //AddMessage('Replacer Form ID: ' + IntToHex(replacerFormID, 8));
   replacerEditorID := GetElementEditValues(replacerRecord, 'EDID');
   // AddMessage('Replacer Editor ID: ' + replacerEditorID);
-  
+
   // リプレイサーNPCのEditor IDからオリジナルのEditor IDを取得
   underscorePos := Pos('_', replacerEditorID);
   originalTargetID := Copy(replacerEditorID, underscorePos + 1, Length(replacerEditorID) - underscorePos);
-  
+
   // オリジナルのEditor IDからターゲットNPCのレコードを取得
   targetRecord := FindRecordByRecordID(originalTargetID, 'NPC_', USE_EDITOR_ID);
-  
+
   if not Assigned(targetRecord) then begin
     AddMessage('Target record not found. Processing will be skipped.');
     Exit;
@@ -262,13 +272,13 @@ begin
   AddMessage('Found record: ' + Name(targetRecord));
   targetFileName := GetFileName(targetRecord);
   AddMessage('Target file name set to: ' + targetFileName);
-  
+
   // ターゲットNPCのFormID,EditorIDを取得
   targetFormID := IntToHex64(GetElementNativeValues(targetRecord, 'Record Header\FormID') and  $FFFFFF, 8);
     //AddMessage('Target Record Form ID: ' + targetFormID);
   targetEditorID := GetElementEditValues(targetRecord, 'EDID');
     //AddMessage('Target Record Editor ID: ' + targetEditorID);
-  
+
   // リプレイサーNPCのフラグ、種族、名前、音声タイプを取得
   replacerFlags            := ElementByPath(replacerRecord, 'ACBS - Configuration');
   replacerRaceElement      := ElementByPath(replacerRecord, 'RNAM');
@@ -276,18 +286,18 @@ begin
   replacerName             := GetElementEditValues(replacerRecord, 'FULL');
   replacerVoiceTypeElement := ElementByPath(replacerRecord, 'VTCK');
   replacerVoiceTypeRecord  := MasterOrSelf(LinksTo(replacerVoiceTypeElement));
-  
+
   // レコードがuse traitsフラグを持っているか確認し、持っていた場合はスキップ
   templateFlags := ElementByPath(replacerFlags, 'Template Flags');
   useTraits := GetElementNativeValues(templateFlags, 'Use Traits') <> 0;
-  
+
   if useTraits then begin
     AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
     AddMessage('This NPC Record has Use Traits Template Flag. Config generation will be skipped.');
     AddMessage('--------------------------------------------------------------------------------------------------------------------------------------------------');
     Exit;
   end;
-  
+
   // ターゲットNPCのフラグ、種族、名前、音声タイプを取得
   targetFlags            := ElementByPath(targetRecord, 'ACBS - Configuration');
   targetRaceElement      := ElementByPath(targetRecord, 'RNAM');
@@ -295,49 +305,52 @@ begin
   targetName             := GetElementEditValues(targetRecord, 'FULL');
   targetVoiceTypeElement := ElementByPath(targetRecord, 'VTCK');
   targetVoiceTypeRecord  := MasterOrSelf(LinksTo(targetVoiceTypeElement));
-  
-  // フォロワーNPCとターゲットNPCの種族、性別、音声タイプを比較して、コメントアウトするか判定。
+
+  // 各設定行の出力が有効かつdisableAllがOFFの場合のみ、比較判定を行う
+  // disableAllがONの場合は、Initializeで既に全てコメントアウトに設定済みなので何もしない
   if not disableAll then begin
-    slCommentOut.Values['Race']      := '';
-    slCommentOut.Values['Gender']    := '';
-    slCommentOut.Values['Name']      := '';
-    slCommentOut.Values['VoiceType'] := '';
-    
-    if GetElementNativeValues(replacerRaceRecord, 'Record Header\FormID') = GetElementNativeValues(targetRaceRecord, 'Record Header\FormID') then begin
-      if not forceEnableRace then
+    // 出力が有効な項目のみコメントアウト判定を行う
+    if outputRace then begin
+      slCommentOut.Values['Race'] := '';
+      // 種族が同じ場合はコメントアウト
+      if GetElementNativeValues(replacerRaceRecord, 'Record Header\FormID') = GetElementNativeValues(targetRaceRecord, 'Record Header\FormID') then
         slCommentOut.Values['Race'] := coChar;
     end;
-      
-    if GetElementEditValues(targetFlags, 'Flags\Female') = GetElementEditValues(replacerFlags, 'Flags\Female') then begin
-      if not forceEnableGender then
+
+    if outputGender then begin
+      slCommentOut.Values['Gender'] := '';
+      // 性別が同じ場合はコメントアウト
+      if GetElementEditValues(targetFlags, 'Flags\Female') = GetElementEditValues(replacerFlags, 'Flags\Female') then
         slCommentOut.Values['Gender'] := coChar;
     end;
-      
-    if replacerName = targetName then begin
-      if not forceEnableName then
+
+    if outputName then begin
+      slCommentOut.Values['Name'] := '';
+      // 名前が同じ場合はコメントアウト
+      if replacerName = targetName then
         slCommentOut.Values['Name'] := coChar;
     end;
-    
-    if GetElementNativeValues(replacerVoiceTypeRecord, 'Record Header\FormID') = GetElementNativeValues(targetVoiceTypeRecord, 'Record Header\FormID') then begin
-      if not forceEnableVoiceType then
+
+    if outputVoiceType then begin
+      slCommentOut.Values['VoiceType'] := '';
+      // 音声タイプが同じ場合はコメントアウト
+      if GetElementNativeValues(replacerVoiceTypeRecord, 'Record Header\FormID') = GetElementNativeValues(targetVoiceTypeRecord, 'Record Header\FormID') then
         slCommentOut.Values['VoiceType'] := coChar;
     end;
   end;
-  
 
-  
   // 出力ファイル用の配列操作
   if useFormID then begin
-    // ゼロパディングしない形式のForm IDを設定、iniファイルへの記入はこちらを利用する  
+    // ゼロパディングしない形式のForm IDを設定、iniファイルへの記入はこちらを利用する
     if  UpperCase(Copy(targetFormID, 1, 2)) = 'FE' then
       trimedTargetFormID := Copy(targetFormID, 6, 8)
     else
       trimedTargetFormID := Copy(targetFormID, 3, 8);
-      
+
     trimedTargetFormID := RemoveLeadingZeros(trimedTargetFormID);
-    
+
     trimedReplacerFormID := IntToHex(replacerFormID and  $FFFFFF, 1);
-    
+
     if useSkyPatcher then begin
       exportTargetID := targetFileName + '|' + trimedTargetFormID;
       exportReplacerID := replacerFileName + '|' + trimedReplacerFormID;
@@ -346,7 +359,7 @@ begin
       exportTargetID := trimedTargetFormID + '~' + targetFileName;
       exportReplacerID := trimedReplacerFormID + '~' + replacerFileName;
     end;
-    
+
     exportRace  := GetFileName(replacerRaceRecord) + '|' + IntToHex(FormID(replacerRaceRecord) and  $FFFFFF, 1);
     exportVoiceType := GetFileName(replacerVoiceTypeRecord) + '|' + IntToHex(FormID(replacerVoiceTypeRecord) and  $FFFFFF, 1);
   end
@@ -356,7 +369,7 @@ begin
     exportRace  := EditorID(replacerRaceRecord);
     exportVoiceType := EditorID(replacerVoiceTypeRecord);
   end;
-  
+
   // NPCレコードのWNAMフィールドが設定されていたらWNAMのスキンを反映。
   // 設定されていない場合はnullでデフォルトボディを指定。
   wnamID := IntToHex(GetElementNativeValues(replacerRecord, 'WNAM') and  $FFFFFF, 1);
@@ -365,30 +378,37 @@ begin
     exportSkinID := 'null'
   else
     exportSkinID := replacerFileName + '|' + wnamID;
-    
+
   // 性別フラグを反映する文字列を入力
   if GetElementEditValues(replacerFlags, 'Flags\Female') = 1 then
     exportGender := ':setFlags=female'
   else
     exportGender := ':removeFlags=female';
-  
+
   // 名前を入力
   exportName := replacerName;
-  
+
   slExport.Add(coChar + GetElementEditValues(targetRecord, 'FULL'));
   slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, useSkyPatcher));
-  
+
   // SkyPatcher利用時のみ出力する
   if useSkyPatcher then begin
     slExport.Add(slCommentOut.Values['Skin'] + 'filterByNpcs=' + exportTargetID + ':skin=' + exportSkinID);
-    slExport.Add(slCommentOut.Values['Race'] + 'filterByNpcs=' + exportTargetID + ':race=' + exportRace);
-    slExport.Add(slCommentOut.Values['Gender'] + 'filterByNpcs=' + exportTargetID + exportGender);
-    if not dontOutputName then
+
+    // 各設定行は対応するoutputフラグがONの場合のみ出力
+    if outputRace then
+      slExport.Add(slCommentOut.Values['Race'] + 'filterByNpcs=' + exportTargetID + ':race=' + exportRace);
+
+    if outputGender then
+      slExport.Add(slCommentOut.Values['Gender'] + 'filterByNpcs=' + exportTargetID + exportGender);
+
+    if outputName then
       slExport.Add(slCommentOut.Values['Name'] + 'filterByNpcs=' + exportTargetID + ':fullName=~' + exportName + '~');
-      
-    slExport.Add(slCommentOut.Values['VoiceType'] + 'filterByNpcs=' + exportTargetID + ':voiceType=' + exportVoiceType);
+
+    if outputVoiceType then
+      slExport.Add(slCommentOut.Values['VoiceType'] + 'filterByNpcs=' + exportTargetID + ':voiceType=' + exportVoiceType);
   end;
-  
+
   slExport.Add(#13#10);
 end;
 
@@ -401,16 +421,16 @@ var
   savedFile:  boolean;
 begin
   savedFile := false;
-  
+
   if callPreProcessor then
     RunPreProcFinalize;
-    
+
   // データがない場合はスキップ
   if slExport.Count = 0 then begin
     slExport.Free;
     Exit;
   end;
-  
+
   // 出力設定の決定
   if useSkyPatcher then begin
     saveDir := DataPath + 'SkyPatcher RDF NPC Replacer Converter\SKSE\Plugins\SkyPatcher\npc\SkyPatcher NPC Replacer Converter\';
@@ -422,11 +442,11 @@ begin
     filterString := 'Txt (*.txt)|*.txt';
     fileExtension := '.txt';
   end;
-  
+
   // ディレクトリ作成
   if not DirectoryExists(saveDir) then
     ForceDirectories(saveDir);
-  
+
   // ファイル保存
   dlgSave := TSaveDialog.Create(nil);
   try
@@ -436,7 +456,7 @@ begin
     dlgSave.FileName := replacerFileName + fileExtension;
     repeat
       savedFile := false;
-      
+
       if not dlgSave.Execute then begin
         // ダイアログを閉じたらループ終了
         AddMessage('Save cancelled by user');
@@ -444,7 +464,7 @@ begin
       end
       else begin
         ExportFileName := dlgSave.FileName;
-        
+
         // ファイルが既に存在するかチェック
         if FileExists(ExportFileName) then begin
           // ユーザーに選択させる
@@ -460,7 +480,7 @@ begin
             [mbYes, mbNo, mbCancel],
             0
           );
-          
+
           case userChoice of
             mrYes: begin
               // 追記モード
@@ -476,7 +496,7 @@ begin
               end;
               savedFile := true;  // ループを抜ける
             end;
-            
+
             mrNo: begin
               // 上書きモード
               AddMessage('Overwriting ' + ExportFileName);
@@ -484,7 +504,7 @@ begin
               AddMessage('File overwritten successfully');
               savedFile := true;  // ループを抜ける
             end;
-            
+
             mrCancel: begin
               // キャンセル
               AddMessage('Save cancelled');

--- a/SP_RDF NPC Replacer Converter - PreProcessor.pas
+++ b/SP_RDF NPC Replacer Converter - PreProcessor.pas
@@ -27,8 +27,8 @@
      - Dependent on standard xEdit functions; no external libraries required.
 
    Author:mmsk4989
-   Version: 2.3.0
-   Last Updated: [2025-11-21]
+   Version: 2.2.1
+   Last Updated: [2026-03-01]
   ==============================================================================
 }
 
@@ -67,12 +67,12 @@ var
   // イニシャル処理で設定・使用する変数
   prefix: string;
   removeFaceGen, removeFaceGenMissingRec, isInputProvided: boolean;
-  
+
   // サマリー用変数
   recordCount, missingFaceGeomCount,
   missingFaceTintCount, missingFaceGenBothCount,
   useTraitsCount, removedRecordCount: integer;
-  
+
   slMissingFaceGeomRecordID,
   slMissingFaceTintRecordID,
   slMissingFaceGenBothRecordID,
@@ -142,7 +142,7 @@ var
 begin
   count := 0;
   group := GroupBySignature(aFile, 'NPC_');
-  
+
   // グループが存在する場合
   if Assigned(group) then begin
     // グループ内のレコード数を取得
@@ -153,7 +153,7 @@ begin
         Inc(count);
     end;
   end;
-  
+
   Result := count;
 end;
 
@@ -178,11 +178,11 @@ begin
   // 次に使用される Form ID の取得
   nextObjectID := GetElementNativeValues(ElementByIndex(f, 0), 'HEDR\Next Object ID');
   AddMessage('Next Object ID:' + IntToHex(nextObjectID and $FFFFFF, 1));
-  
+
   // NPCレコードの数を取得
   npcRecordNum := GetNPCRecordCount(f);
   AddMessage('NPC Records:' + IntToStr(npcRecordNum));
-  
+
   // ヘッダーバージョンに応じて変化する値の設定
   if headerVer < EXTESLVER then begin
     // レコード最大数を設定
@@ -190,7 +190,7 @@ begin
     // 使用済みForm IDの数を設定
     if (nextObjectID >= ESLSTARTFORMID) and (nextObjectID <= ESLMAXFORMID) then
       numUsedFormID := nextObjectID - ESLSTARTFORMID
-    else 
+    else
       numUsedFormID := nextObjectID;
   end
   else begin
@@ -204,13 +204,13 @@ begin
     else
       numUsedFormID := nextObjectID;
   end;
-  
+
   AddMessage('Max Record Count:' + IntToStr(maxRecordNum));
-  
+
   // 利用可能なForm ID数の予想値を計算
   estRemainingFormID := maxRecordNum - numUsedFormID;
   AddMessage('Estimate Remaining Form IDs:' + IntToStr(estRemainingFormID));
-  
+
   // Next Object IDが制限範囲を超えていないか判定
   if headerVer < EXTESLVER then begin
     if (nextObjectID < ESLSTARTFORMID) or (nextObjectID > ESLMAXFORMID) then
@@ -220,7 +220,7 @@ begin
     if nextObjectID > ESLMAXFORMID then
       invalidObjectID := true;
   end;
-    
+
 
 
   // Form IDの判定
@@ -235,7 +235,7 @@ begin
     Result := true;
     Exit;
   end;
-  
+
   // Form IDの空きスペースが足りない
   if (estRemainingFormID > 0) and (npcRecordNum > estRemainingFormID) then begin
     AddMessage('Script aborted: Not enough Form ID space.');
@@ -247,7 +247,7 @@ begin
     Result := true;
     Exit;
   end;
-  
+
   // レコード数が上限以上
   if recordNum >= maxRecordNum then begin
     AddMessage('Script aborted: Too many records.');
@@ -276,38 +276,38 @@ begin
   try
     nif := TwbNifFile.Create;
     nif.LoadFromFile(faceMeshPath);
-    
+
     findFaceTintPath := false;
-    
+
     lTextureList := TList.Create;
-    
+
     // Iterate over all blocks in a nif file and locate elements holding textures.
     for i := 0 to nif.BlocksCount - 1 do begin
         block := nif.Blocks[i];
-        
+
         if block.BlockType = 'BSShaderTextureSet' then begin
             element := block.Elements['Textures'];
             for j := 0 to element.Count - 1 do
                 lTextureList.Add(element[j]);
-        end; 
+        end;
     end;
-    
+
     //AddMessage(Format('Found %d elements.', [Elements.Count]));
-    
+
     // Skip to the next file If nothing was found.
     if lTextureList.Count = 0 then
       Exit;
-    
+
     // Do text replacement in collected elements.
     for i := 0 to lTextureList.Count - 1 do begin
       if not Assigned(lTextureList[i]) then
         continue;
 
       element := TdfElement(lTextureList[i]);
-      
+
       if element.EditValue = '' then
         continue;
-        
+
       if Pos(LowerCase('FaceTint'), LowerCase(element.EditValue)) > 0 then begin
         findFaceTintPath := true;
         faceTintElement := element;
@@ -315,12 +315,12 @@ begin
         break;
       end;
     end;
-    
+
     if not findFaceTintPath then begin
       AddMessage('FaceTint file path not found.');
       Exit;
     end;
-    
+
     // 新しいFaceTintパスをnifファイルに設定
     key := 'textures\actors\character\FaceGenData\FaceTint\';
     p := Pos(LowerCase(key), LowerCase(faceTextureFullPath));
@@ -352,7 +352,7 @@ begin
       AddMessage('[' + currentFile + ']');
       lastFile := currentFile;
     end;
-    
+
     // NPCの名前がない場合は(NONE)を表示
     if ExtractStringListValue(slMissing.ValueFromIndex[i], 'NPCName') = '' then
       displayNPCName := '(NONE)'
@@ -385,24 +385,24 @@ begin
   removeFaceGenMissingRec   := false;
   isInputProvided     := false;
   validInput          := false;
-  
+
   recordCount                 := 0;
   missingFaceGeomCount        := 0;
   missingFaceTintCount        := 0;
   missingFaceGenBothCount     := 0;
   useTraitsCount              := 0;
   removedRecordCount          := 0;
-  
+
   slMissingFaceGeomRecordID     := TStringList.Create;
   slMissingFaceTintRecordID     := TStringList.Create;
   slMissingFaceGenBothRecordID  := TStringList.Create;
   slMissingFaceGenWithUseTraits := TStringList.Create;
-  
+
   slOpts                := TStringList.Create;
   slDisableOpts         := TStringList.Create;
-  
+
   checkBoxCaption             := 'Choose PreProcessor Option';
-  
+
   Result              := 0;
 
 
@@ -423,14 +423,14 @@ begin
       Result := -1;
       Exit;
     end;
-    
+
 
     // コピー元のFaceGenファイルを残すか
     removeFaceGen := GetBoolSLValue(slOpts.Values['Remove FaceGen files in the replacer mod']);
-    
+
     // FaceGenファイルを持たないNPCレコードをコピーするか
     removeFaceGenMissingRec := GetBoolSLValue(slOpts.Values['Remove NPC records without FaceGen files']);
-      
+
   finally
     slOpts.Free;
     slDisableOpts.Free;
@@ -461,7 +461,7 @@ begin
         validInput := false;
       end;
     end;
-      
+
     if validInput = false then
       prefix := '';
 
@@ -528,10 +528,10 @@ begin
   // Mod名を取得（レコードが所属するファイル名）
   replacerFileName := GetFileName(GetFile(e));
   baseFileName := GetFileName(GetFile(MasterOrSelf(e)));
-  
+
   //AddMessage('firstRecordFileName:' + firstRecordFileName);
   //AddMessage('Now plugin name:' + replacerFileName);
-  
+
   // 最初のレコードが所属するプラグインと異なるプラグインが選択されていたらスキップ
   compareStrRslt := CompareStr(firstRecordFileName, replacerFileName);
   //AddMessage('Set compareStrRslt:' + IntToStr(compareStrRslt));
@@ -551,9 +551,9 @@ begin
     AddMessage(GetElementEditValues(e, 'EDID') + ' does not overwrite other record.');
     Exit;
   end;
-  
+
   Inc(recordCount);
-  
+
   // フラグを初期化
   missingFacegeom := false;
   missingFacetint := false;
@@ -574,7 +574,7 @@ begin
     AddMessage('File not found: ' + oldMeshPath);
     missingFacegeom := true
   end;
-  
+
   if not FileExists(oldTexturePath) then begin
     AddMessage('File not found: ' + oldTexturePath);
     missingFacetint := true;
@@ -584,11 +584,11 @@ begin
   recordFlag := GetElementNativeValues(ElementBySignature(e, 'ACBS'), 'Template Flags');
   if (recordFlag and $01) <> 0 then
     useTraitsFlag := true;
-  
+
   // レコードID,ファイル名を変数に格納
   recordID := 'Form ID: ' + oldFormID + ', Editor ID: ' + oldEditorID;
   recordFileName := GetFileName(MasterOrSelf(e));
-  
+
   // FaceGenファイルが存在しない場合の処理
   // FaceGeomかFaceTintのどちらも存在していない場合
   if missingFacegeom and missingFacetint then begin
@@ -603,7 +603,7 @@ begin
       Remove(e);
       Exit;
     end;
-    
+
     // Use Traitsフラグを持っていない場合は異常と判断し、処理をスキップ
     if useTraitsFlag then begin
       AddMessage('This record (' + recordID + ') uses a template and has the Use Traits flag, so it''s normal that it doesn''t have FaceGen files.');
@@ -634,8 +634,8 @@ begin
     slMissingFaceTintRecordID.Add(CreateSLValueFromRecordIDWithName(oldEditorID, oldFormID, recordFileName, NPCName));
     Exit;
   end;
-  
-  
+
+
   // レコードを複製
   newRecord := wbCopyElementToFile(e, GetFile(e), True, True);
   if not Assigned(newRecord) then begin
@@ -649,7 +649,7 @@ begin
   newEditorID := prefix + '_' + oldEditorID;
   SetElementEditValues(newRecord, 'EDID', newEditorID);
   // AddMessage('Created new record with Editor ID: ' + newEditorID);
-  
+
   // 新しいFaceGenファイルのパスを取得
   newMeshPath := GetFaceGenPath(replacerFileName, newFormID, true, MESHMODE);
 //    AddMessage('newMeshPath:' + newMeshPath);
@@ -664,10 +664,10 @@ begin
       ReplaceFaceTintPath(newMeshPath, newTexturePath);
     end;
   end;
-  
+
   if Assigned(newRecord) then
     createdRecord := newRecord;
-  
+
   // コピー元レコードを削除
   Remove(e);
 
@@ -679,21 +679,21 @@ begin
   AddMessage('Total Records Processed: ' + IntToStr(recordCount));
   AddMessage('Total Records with Missing FaceGen Files: ' + IntToStr(missingFaceGenBothCount + missingFaceGeomCount + missingFaceTintCount));
   AddMessage('Total Removed Records: ' + IntToStr(removedRecordCount));
-  
+
   AddMessage(#13#10 + 'Records Missing Both FaceGen Files: ' + IntToStr(missingFaceGenBothCount));
   DisplayMissingFaceGenRecordID(slMissingFaceGenBothRecordID);
-  
+
   AddMessage(#13#10 + 'with UseTraits Flag: ' + IntToStr(useTraitsCount));
   DisplayMissingFaceGenRecordID(slMissingFaceGenWithUseTraits);
-  
+
   AddMessage(#13#10 + 'Records Missing FaceGeom File: ' + IntToStr(missingFaceGeomCount));
   DisplayMissingFaceGenRecordID(slMissingFaceGeomRecordID);
-    
+
   AddMessage(#13#10 + 'Records Missing FaceTint File: ' + IntToStr(missingFaceTintCount));
   DisplayMissingFaceGenRecordID(slMissingFaceTintRecordID);
-  
+
   AddMessage(#13#10 + '------------------------------PreProcessing Summary End------------------------------');
-  
+
   slMissingFaceGenBothRecordID.Free;
   slMissingFaceGenWithUseTraits.Free;
   slMissingFaceGeomRecordID.Free;


### PR DESCRIPTION
ConfigGeneratorを編集

- Force Replaceオプションの挙動を変更
  - オプションの選択を、必ず有効にするかどうかではなく、設定行の出力をするかどうかを選ぶようにした。出力する場合は従来通りの有効無効の判定を行う。
- Outfitオプションの追加
