### PR TITLE
Supports recast

### DIFF
--- a/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
+++ b/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
@@ -222,7 +222,16 @@ begin
     Result := '0'
   else
     Result := Copy(s, i, Length(s) - i + 1);
-    Result := Copy(s, i, Length(s) - i + 1);
+end;
+
+function PadLeftZero(const s: string; targetLength: Integer): string;
+var
+  padded: string;
+begin
+  padded := s;
+  while Length(padded) < targetLength do
+    padded := '0' + padded;
+  Result := padded;
 end;
 
 function FindRecordByRecordID(const recordID, signature: string; useFormID: boolean): IwbMainRecord;

--- a/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
+++ b/NPC Replacer Converter - Shared/NPCRC_CommonUtils.pas
@@ -42,19 +42,19 @@ var
   startPos, endPos: Integer;
 begin
   Result := '';
-  
+
   // "Key="形式で検索
   searchStr := key + '=';
   startPos := Pos(searchStr, valueString);
-  
+
   if startPos = 0 then Exit;
-  
+
   // 値の開始位置
   startPos := startPos + Length(searchStr);
-  
+
   // 次の;を探す（値の終わり）
   endPos := Pos(';', Copy(valueString, startPos, Length(valueString)));
-  
+
   if endPos > 0 then
     // ;が見つかった場合、そこまでを取得
     Result := Copy(valueString, startPos, endPos - 1)
@@ -77,7 +77,7 @@ begin
 {  AddMessage('=== Debug Info ===');
   AddMessage('Options count: ' + IntToStr(options.Count));
   AddMessage('DisableOpts count: ' + IntToStr(disableOpts.Count));
-}  
+}
   form := TForm.Create(nil);
   try
     form.Caption := caption;
@@ -92,30 +92,30 @@ begin
 
     for i := 0 to options.Count - 1 do begin
       checklist.Items.Add(options.Names[i]);
-      
+
       shouldDisable := false;
-      
+
       // このオプションを無効化すべきか判定
       shouldDisable := (disableOpts.Count > 0) and (disableOpts.IndexOf(options.Names[i]) >= 0);
-      
+
       // デバッグ: 各項目の判定結果
 {      AddMessage('Item ' + IntToStr(i) + ': ' + options.ValueFromIndex[i]);
-      
+
       if shouldCheck then
         AddMessage('  shouldCheck: True')
       else
         AddMessage('  shouldCheck: False');
-            
+
       if shouldDisable then
         AddMessage('  shouldDisable: True')
       else
         AddMessage('  shouldDisable: False');
 }
-      
+
       // このオプションをチェックすべきか判定
       if GetBoolSLValue(options.ValueFromIndex[i]) then
         checklist.Checked[i] := true;
-      
+
       // 注意：ItemEnabledはtrue:無効化、false:有効化となる
       // 一般的な論理イメージと逆転している。
       if shouldDisable then begin
@@ -215,12 +215,13 @@ var
 begin
   i := 1;
   // 先頭の '0' をスキップ
-  while (i <= Length(s)) and (s[i] = '0') do
+  while (i <= Length(s)) and (Copy(s, i, 1) = '0') do
     Inc(i);
   // すべてが '0' の場合は '0' を返す
   if i > Length(s) then
     Result := '0'
   else
+    Result := Copy(s, i, Length(s) - i + 1);
     Result := Copy(s, i, Length(s) - i + 1);
 end;
 
@@ -233,7 +234,7 @@ var
   npcRecordGroup: IwbGroupRecord;
 begin
   Result := nil;
-  
+
   if useFormID then begin
     // StrToIntでは負数になってしまうので、StrToInt64で変換し、Cardinal型で受け取る。
     formID := StrToInt64('$' + recordID);

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -508,7 +508,7 @@ begin
   else if framework = 'Recast' then begin
     // RecastはWNAMにデフォルトボディを指定する方法がないため、未設定の場合は設定行を出力しない
     if wnamID = '0' then
-      skipSkinThisRecord := false
+      skipSkinThisRecord := true
     else
       exportSkinID := wnamID + '~' + replacerFileName;
   end;
@@ -562,7 +562,7 @@ begin
     slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
 
     // 各設定行は対応するoutputフラグがONの場合のみ出力
-    if outputSkin and not skipSkinThisRecord then
+    if outputSkin = true and not skipSkinThisRecord then
       slExport.Add(slCommentOut.Values['Skin'] + 'body = "' + exportSkinID + '"');
 
     // RaceはRecastでは未対応だが、将来的に対応する可能性があるため、コメントとして残しておく

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -6,32 +6,34 @@
    Description:
      This script is part of the "SkyPatcher RDF NPC Replacer Converter" toolset.
      It functions as the *Config Generator (ConfigGen)* phase, executed after
-     the PreProcessor. Its purpose is to create configuration files for either
-     **SkyPatcher** or **Race Distribution Framework (RDF)** based on user-selected
-     options and NPC record data gathered from the list of plugins currently loaded
-     in xEdit.
+     the PreProcessor. Its purpose is to create configuration files for
+     **SkyPatcher**, **Race Distribution Framework (RDF)**, or **Recast** based
+     on user-selected options and NPC record data gathered from the list of
+     plugins currently loaded in xEdit.
 
    Features:
      - Integrates seamlessly with the PreProcessor phase (optional).
-     - Prompts user to select output mode (SkyPatcher / RDF) and generation options.
+     - Prompts user to select output framework (SkyPatcher / RDF / Recast)
+       and generation options via checkboxes.
      - Scans and compares NPC records (original vs. replacer) to determine
-       which parameters (appearance, race, gender, etc.) should be replaced.
-     - Generates structured `.ini` (for SkyPatcher) or `.txt` (for RDF) config files.
+       which parameters (appearance, gender, name, etc.) should be replaced.
+     - Generates structured `.ini` (SkyPatcher), `.txt` (RDF), or `.toml` (Recast)
+       config files.
      - Automatically comments out or enables settings according to user preferences.
 
    Usage:
      1. Run this script in xEdit (SSEEdit) on your replacer plugin.
      2. Select whether to run in Integration Mode (to invoke PreProcessor).
-     3. Choose your config generation target (SkyPatcher or RDF).
+     3. Choose your config generation target (SkyPatcher / RDF / Recast).
      4. Select desired options in the checklist dialog.
-     5. The script will process NPC records and output a ready-to-use config file
-        under the `Data\SkyPatcher RDF NPC Replacer Converter\...` directory.
+     5. The script will process NPC records and output a ready-to-use config file.
 
    Notes:
-      - Intended for Skyrim SE/AE with SkyPatcher and RDF support.
+      - Intended for Skyrim SE/AE with SkyPatcher, RDF, and Recast support.
       - Uses `SP_RDF_NPCReplacerConverter_PreProcessor.pas` when Integration Mode is selected.
       - This script can also be run standalone if the PreProcessor has already been applied.
       - Compatible with both FormID- and EditorID-based reference methods.
+      - Recast does not support Race replacement or Outfit output.
 
    Author:mmsk4989
    Version: 2.3.0
@@ -56,13 +58,16 @@ const
 var
   // 設定ファイル出力用変数
   slExport, slCommentOut: TStringList;
-  coChar, targetFileName, replacerFileName, framework: string;
+  coChar, targetFileName, replacerFileName: string;
 
   // イニシャル処理で設定・使用する変数
-  callPreProcessor, useFormID, disableAll, replaceVS, replaceSkin: boolean;
+  callPreProcessor, useFormID, disableAll, replaceVS: boolean;
 
-  // Output setting フラグ - ONの場合のみ該当の設定行を出力する
-  outputRace, outputGender, outputName, outputVoiceType, outputOutfit: boolean;
+  // 選択中のフレームワーク ('SkyPatcher' / 'RDF' / 'Recast')
+  framework: string;
+
+  // Output フラグ - ONの場合のみ該当の設定行を出力する
+  outputSkin, outputRace, outputGender, outputName, outputVoiceType, outputOutfit: boolean;
 
 function GenerateVisualStyleString(const targetID, replacerID, fw: string): string;
 begin
@@ -133,6 +138,17 @@ begin
   end;
 end;
 
+procedure InsertRecastManifest;
+begin
+  if framework = 'Recast' then begin
+    slExport.Insert(0, '');
+    slExport.Insert(0, 'api_version = 1');
+    slExport.Insert(0, 'priority = 100');
+    slExport.Insert(0, 'name = "' + replacerFileName + '"');
+    slExport.Insert(0, '[manifest]');
+  end;
+end;
+
 function Initialize: integer;
 var
   validInput: boolean;
@@ -149,9 +165,9 @@ begin
 
   disableAll          := false;
   replaceVS           := false;
-  replaceSkin         := false;
 
   // Output setting オプションのデフォルト値を設定
+  outputSkin          := false;
   outputRace          := false;
   outputGender        := false;
   outputName          := false;
@@ -212,7 +228,7 @@ begin
     opts.Values['Use Form ID for config file output'] := 'False';
     opts.Values['Disable the config file by default'] := 'False';
     opts.Values['Replace Visual Style']               := 'False';
-    opts.Values['Replace Skin']                       := 'False';
+    opts.Values['Output Skin or body setting']        := 'False';
     opts.Values['Output Race setting']                := 'False';
     opts.Values['Output Gender setting']              := 'False';
     opts.Values['Output Name setting']                := 'False';
@@ -221,11 +237,11 @@ begin
 
     if framework = 'SkyPatcher' then begin
       opts.Values['Replace Visual Style'] := 'True';
-      opts.Values['Replace Skin']         := 'True';
+      opts.Values['Output Skin or body setting']         := 'True';
     end
     else if framework = 'Recast' then begin
       opts.Values['Replace Visual Style'] := 'True';
-      opts.Values['Replace Skin']         := 'True';
+      opts.Values['Output Skin or body setting']         := 'True';
       // RecastはRaceとOutfitに未対応のため無効化
       disableOpts.Add('Output Race setting');
       disableOpts.Add('Output Outfit setting');
@@ -233,7 +249,7 @@ begin
     else begin
       // RDFはSkyPatcher専用オプションを無効化
       disableOpts.Add('Replace Visual Style');
-      disableOpts.Add('Replace Skin');
+      disableOpts.Add('Output Skin or body setting');
       disableOpts.Add('Output Race setting');
       disableOpts.Add('Output Gender setting');
       disableOpts.Add('Output Name setting');
@@ -261,7 +277,7 @@ begin
 
     // SkyPatcher、Recast利用時のオプション設定
     replaceVS       := GetBoolSLValue(opts.Values['Replace Visual Style']);    // 見た目を変更するか
-    replaceSkin     := GetBoolSLValue(opts.Values['Replace Skin']);            // 肌を変更するか
+    outputSkin      := GetBoolSLValue(opts.Values['Output Skin or body setting']);            // 肌を変更するか
 
     // 各設定行を出力するかどうか（ONの場合のみ出力）
     outputRace      := GetBoolSLValue(opts.Values['Output Race setting']);
@@ -285,7 +301,7 @@ begin
       if (framework <> 'RDF') and not replaceVS then
         slCommentOut.Values['CopyVS'] := coChar;
 
-      if not replaceSkin then
+      if not outputSkin then
         slCommentOut.Values['Skin'] := coChar;
     end;
 
@@ -307,7 +323,7 @@ var
   replacerName, targetName: string;
   replacerFormID, underscorePos: Cardinal;
   originalTargetID, recordSignature, targetFormID, targetEditorID, replacerEditorID: string; // レコードID関連
-  trimedTargetFormID, trimedReplacerFormID, exportTargetID, exportReplacerID, wnamID, exportSkinID, exportRace, exportGender, exportName, exportVoiceType, exportOutfit: string; // SkyPatcher iniファイルの記入用
+  trimedTargetFormID, trimedReplacerFormID, exportTargetID, exportReplacerID, wnamID, exportSkinID, exportRace, exportGender, exportName, exportVoiceType, exportOutfit: string; // SkyPatcher, Recast設定ファイルの記入用
   useTraits: boolean;
 begin
   targetFormID    := '';
@@ -358,7 +374,7 @@ begin
   targetEditorID := GetElementEditValues(targetRecord, 'EDID');
     //AddMessage('Target Record Editor ID: ' + targetEditorID);
 
-  // リプレイサーNPCのフラグ、種族、名前、音声タイプを取得
+  // リプレイサーNPCのフラグ、種族、名前、音声タイプ、装備を取得
   replacerFlags            := ElementByPath(replacerRecord, 'ACBS - Configuration');
   replacerRaceElement      := ElementByPath(replacerRecord, 'RNAM');
   replacerRaceRecord       := MasterOrSelf(LinksTo(replacerRaceElement));
@@ -379,7 +395,7 @@ begin
     Exit;
   end;
 
-  // ターゲットNPCのフラグ、種族、名前、音声タイプを取得
+  // ターゲットNPCのフラグ、種族、名前、音声タイプ、装備を取得
   targetFlags            := ElementByPath(targetRecord, 'ACBS - Configuration');
   targetRaceElement      := ElementByPath(targetRecord, 'RNAM');
   targetRaceRecord       := MasterOrSelf(LinksTo(targetRaceElement));
@@ -393,6 +409,13 @@ begin
   // disableAllがONの場合は、Initializeで既に全てコメントアウトに設定済みなので何もしない
   if not disableAll then begin
     // 出力が有効な項目のみコメントアウト判定を行う
+    if outputSkin then begin
+      slCommentOut.Values['Skin'] := '';
+      // 肌が同じ場合はコメントアウト
+      if GetElementNativeValues(replacerRecord, 'WNAM') = GetElementNativeValues(targetRaceRecord, 'WNAM') then
+        slCommentOut.Values['Skin'] := coChar;
+    end;
+
     if outputRace then begin
       slCommentOut.Values['Race'] := '';
       // 種族が同じ場合はコメントアウト
@@ -444,15 +467,24 @@ begin
     if framework = 'SkyPatcher' then begin
       exportTargetID := targetFileName + '|' + trimedTargetFormID;
       exportReplacerID := replacerFileName + '|' + trimedReplacerFormID;
+      exportRace  := GetFileName(replacerRaceRecord) + '|' + IntToHex(FormID(replacerRaceRecord) and  $FFFFFF, 1);
+      exportVoiceType := GetFileName(replacerVoiceTypeRecord) + '|' + IntToHex(FormID(replacerVoiceTypeRecord) and  $FFFFFF, 1);
+      exportOutfit := GetFileName(replacerOutfitRecord) + '|' + IntToHex(FormID(replacerOutfitRecord) and  $FFFFFF, 1);
+    end
+    else if framework = 'Recast' then begin
+      //exportTargetID := '0x' + targetFormID + '~' + targetFileName;
+      //exportReplacerID := '0x' + replacerFormID + '~' + replacerFileName;
+      exportTargetID := trimedTargetFormID + '~' + targetFileName;
+      exportReplacerID := trimedReplacerFormID + '~' + replacerFileName;
+      exportRace  := IntToHex(FormID(replacerRaceRecord) and  $FFFFFF, 1) + '~' + GetFileName(replacerRaceRecord);
+      exportVoiceType := IntToHex(FormID(replacerVoiceTypeRecord) and  $FFFFFF, 1) + '~' + GetFileName(replacerVoiceTypeRecord);
+      exportOutfit := IntToHex(FormID(replacerOutfitRecord) and  $FFFFFF, 1) + '~' + GetFileName(replacerOutfitRecord);
     end
     else begin
       exportTargetID := trimedTargetFormID + '~' + targetFileName;
       exportReplacerID := trimedReplacerFormID + '~' + replacerFileName;
     end;
 
-    exportRace  := GetFileName(replacerRaceRecord) + '|' + IntToHex(FormID(replacerRaceRecord) and  $FFFFFF, 1);
-    exportVoiceType := GetFileName(replacerVoiceTypeRecord) + '|' + IntToHex(FormID(replacerVoiceTypeRecord) and  $FFFFFF, 1);
-    exportOutfit := GetFileName(replacerOutfitRecord) + '|' + IntToHex(FormID(replacerOutfitRecord) and  $FFFFFF, 1);
   end
   else begin
     exportTargetID := targetEditorID;
@@ -466,28 +498,48 @@ begin
   // 設定されていない場合はnullでデフォルトボディを指定。
   wnamID := IntToHex(GetElementNativeValues(replacerRecord, 'WNAM') and  $FFFFFF, 1);
   //  AddMessage('wnamID is:' + wnamID);
-  if wnamID = '0' then
-    exportSkinID := 'null'
-  else
-    exportSkinID := replacerFileName + '|' + wnamID;
+  if framework = 'SkyPatcher' then begin
+    if wnamID = '0' then
+      exportSkinID := 'null'
+    else
+      exportSkinID := wnamID;
+  end
+  else if framework = 'Recast' then begin
+    // RecastはWNAMにデフォルトボディを指定する方法がないため、未設定の場合は設定行を出力しない
+    if wnamID = '0' then
+      outputSkin := false
+    else
+      exportSkinID := wnamID + '~' + replacerFileName;
+  end;
 
   // 性別フラグを反映する文字列を入力
-  if GetElementEditValues(replacerFlags, 'Flags\Female') = 1 then
-    exportGender := ':setFlags=female'
-  else
-    exportGender := ':removeFlags=female';
+  if framework = 'SkyPatcher' then begin
+    if GetElementEditValues(replacerFlags, 'Flags\Female') = 1 then
+      exportGender := ':setFlags=female'
+    else
+      exportGender := ':removeFlags=female';
+  end
+  else if framework = 'Recast' then begin
+    if GetElementEditValues(replacerFlags, 'Flags\Female') = 1 then
+      exportGender := 'female'
+    else
+      exportGender := 'male';
+  end;
 
   // 名前を入力
   exportName := replacerName;
 
+  // 設定行の見出しとして、ターゲットNPCの名前、FormID、EditorIDを出力する
   slExport.Add(coChar + GetElementEditValues(targetRecord, 'FULL'));
-  slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
+  slExport.Add(coChar + 'Form ID: ' + targetFormID + '  Editor ID: ' + targetEditorID);
 
-  // SkyPatcher利用時のみ出力する
   if framework = 'SkyPatcher' then begin
-    slExport.Add(slCommentOut.Values['Skin'] + 'filterByNpcs=' + exportTargetID + ':skin=' + exportSkinID);
+    slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
 
     // 各設定行は対応するoutputフラグがONの場合のみ出力
+    if outputSkin then
+      slExport.Add(slCommentOut.Values['Skin'] + 'filterByNpcs=' + exportTargetID + ':skin=' + exportSkinID);
+
     if outputRace then
       slExport.Add(slCommentOut.Values['Race'] + 'filterByNpcs=' + exportTargetID + ':race=' + exportRace);
 
@@ -502,6 +554,32 @@ begin
 
     if outputOutfit then
       slExport.Add(slCommentOut.Values['Outfit'] + 'filterByNpcs=' + exportTargetID + ':outfitDefault=' + exportOutfit);
+  end
+  else if framework = 'Recast' then begin
+    slExport.Add('[[npcs]]');
+    slExport.Add('target = "' + exportTargetID + '"');
+    slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
+
+    // 各設定行は対応するoutputフラグがONの場合のみ出力
+    if outputSkin then
+      slExport.Add(slCommentOut.Values['Skin'] + 'body = "' + exportSkinID + '"');
+
+    // RaceはRecastでは未対応だが、将来的に対応する可能性があるため、コメントとして残しておく
+    //if outputRace then
+    //  slExport.Add(slCommentOut.Values['Race'] + 'race ="' + exportRace + '"');
+
+    if outputGender then
+      slExport.Add(slCommentOut.Values['Gender'] + 'sex = "' + exportGender + '"');
+
+    if outputName then
+      slExport.Add(slCommentOut.Values['Name'] +  'name = "' + exportName + '"');
+
+    if outputVoiceType then
+      slExport.Add(slCommentOut.Values['VoiceType'] + + 'voice = "' + exportVoiceType + '"');
+
+  end
+  else if framework = 'RDF' then begin
+    slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
   end;
 
   slExport.Add(#13#10);
@@ -532,7 +610,12 @@ begin
     filterString := 'Ini (*.ini)|*.ini';
     fileExtension := '.ini';
   end
-  else begin
+  else if framework = 'Recast' then begin
+    saveDir := DataPath + 'SkyPatcher RDF NPC Replacer Converter\SKSE\Plugins\Recast\Patches\';
+    filterString := 'Toml (*.toml)|*.toml';
+    fileExtension := '.toml';
+  end
+  else if framework = 'RDF' then begin
     saveDir := DataPath + 'SkyPatcher RDF NPC Replacer Converter\SKSE\Plugins\RaceSwap\';
     filterString := 'Txt (*.txt)|*.txt';
     fileExtension := '.txt';
@@ -594,6 +677,7 @@ begin
 
             mrNo: begin
               // 上書きモード
+              InsertRecastManifest;
               AddMessage('Overwriting ' + ExportFileName);
               slExport.SaveToFile(ExportFileName);
               AddMessage('File overwritten successfully');
@@ -609,6 +693,7 @@ begin
         end
         else begin
           // ファイルが存在しない場合は通常通り保存
+          InsertRecastManifest;
           AddMessage('Saving ' + ExportFileName);
           slExport.SaveToFile(ExportFileName);
           AddMessage('File saved successfully');

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -324,12 +324,13 @@ var
   replacerFormID, underscorePos: Cardinal;
   originalTargetID, recordSignature, targetFormID, targetEditorID, replacerEditorID: string; // レコードID関連
   trimedTargetFormID, trimedReplacerFormID, exportTargetID, exportReplacerID, wnamID, exportSkinID, exportRace, exportGender, exportName, exportVoiceType, exportOutfit: string; // SkyPatcher, Recast設定ファイルの記入用
-  useTraits: boolean;
+  useTraits, skipSkinThisRecord: boolean;
 begin
   targetFormID    := '';
   targetEditorID  := '';
 
   recordSignature := 'NPC_';
+  skipSkinThisRecord := false;
 
 
   // NPCレコードでなければスキップ
@@ -412,7 +413,7 @@ begin
     if outputSkin then begin
       slCommentOut.Values['Skin'] := '';
       // 肌が同じ場合はコメントアウト
-      if GetElementNativeValues(replacerRecord, 'WNAM') = GetElementNativeValues(targetRaceRecord, 'WNAM') then
+      if GetElementNativeValues(replacerRecord, 'WNAM') = GetElementNativeValues(targetRecord, 'WNAM') then
         slCommentOut.Values['Skin'] := coChar;
     end;
 
@@ -502,12 +503,12 @@ begin
     if wnamID = '0' then
       exportSkinID := 'null'
     else
-      exportSkinID := wnamID;
+      exportSkinID := replacerFileName + '|' + wnamID;
   end
   else if framework = 'Recast' then begin
     // RecastはWNAMにデフォルトボディを指定する方法がないため、未設定の場合は設定行を出力しない
     if wnamID = '0' then
-      outputSkin := false
+      skipSkinThisRecord := false
     else
       exportSkinID := wnamID + '~' + replacerFileName;
   end;
@@ -561,7 +562,7 @@ begin
     slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
 
     // 各設定行は対応するoutputフラグがONの場合のみ出力
-    if outputSkin then
+    if outputSkin and not skipSkinThisRecord then
       slExport.Add(slCommentOut.Values['Skin'] + 'body = "' + exportSkinID + '"');
 
     // RaceはRecastでは未対応だが、将来的に対応する可能性があるため、コメントとして残しておく
@@ -575,7 +576,7 @@ begin
       slExport.Add(slCommentOut.Values['Name'] +  'name = "' + exportName + '"');
 
     if outputVoiceType then
-      slExport.Add(slCommentOut.Values['VoiceType'] + + 'voice = "' + exportVoiceType + '"');
+      slExport.Add(slCommentOut.Values['VoiceType'] +  'voice = "' + exportVoiceType + '"');
 
   end
   else if framework = 'RDF' then begin

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -56,21 +56,81 @@ const
 var
   // 設定ファイル出力用変数
   slExport, slCommentOut: TStringList;
-  coChar, targetFileName, replacerFileName: string;
+  coChar, targetFileName, replacerFileName, framework: string;
 
   // イニシャル処理で設定・使用する変数
-  callPreProcessor, useSkyPatcher, useFormID, disableAll, replaceVS, replaceSkin: boolean;
+  callPreProcessor, useFormID, disableAll, replaceVS, replaceSkin: boolean;
 
   // Output setting フラグ - ONの場合のみ該当の設定行を出力する
   outputRace, outputGender, outputName, outputVoiceType, outputOutfit: boolean;
 
-function GenerateVisualStyleString(const targetID, replacerID: string; useSkyPatcher: boolean): string;
+function GenerateVisualStyleString(const targetID, replacerID, fw: string): string;
 begin
   Result := '';
-    if useSkyPatcher then
-      Result := 'filterByNpcs=' + TargetID + ':copyVisualStyle=' + ReplacerID
-    else
-      Result := 'match=' + TargetID + ' swap=' + ReplacerID;
+  if fw = 'SkyPatcher' then
+    Result := 'filterByNpcs=' + TargetID + ':copyVisualStyle=' + ReplacerID
+  else if fw = 'Recast' then
+    Result := 'face = "' + ReplacerID + '"'
+  else
+    Result := 'match=' + TargetID + ' swap=' + ReplacerID;
+end;
+
+// フレームワーク選択（チェックボックス方式、排他制御あり）
+// 複数選択された場合はエラーを表示して再選択させる
+function SelectFramework: string;
+var
+  opts, disableOpts: TStringList;
+  skyPatcherSelected, rdfSelected, recastSelected: Boolean;
+  selectedCount: Integer;
+begin
+  Result := '';
+  opts := TStringList.Create;
+  disableOpts := TStringList.Create;
+  try
+    opts.Values['SkyPatcher'] := 'True';
+    opts.Values['RDF (Race Distribution Framework)'] := 'False';
+    opts.Values['Recast'] := 'False';
+
+    if not ShowCheckboxForm(opts, disableOpts, 'Select Framework (choose only one)') then begin
+      AddMessage('Selection was canceled.');
+      Exit;
+    end;
+
+    skyPatcherSelected := GetBoolSLValue(opts.Values['SkyPatcher']);
+    rdfSelected        := GetBoolSLValue(opts.Values['RDF (Race Distribution Framework)']);
+    recastSelected     := GetBoolSLValue(opts.Values['Recast']);
+
+    selectedCount := 0;
+    if skyPatcherSelected then Inc(selectedCount);
+    if rdfSelected then Inc(selectedCount);
+    if recastSelected then Inc(selectedCount);
+    // AddMessage('Selected Count: ' + IntToStr(selectedCount));
+
+    // 複数選択された場合はエラーを表示して再選択させる
+    if selectedCount > 1 then begin
+      MessageDlg('Please select only one framework.', mtError, [mbOK], 0);
+      Result := SelectFramework; // 再選択
+      Exit;
+    end;
+
+    // 何も選択されなかった場合もエラーを表示して再選択させる
+    if selectedCount = 0 then begin
+      MessageDlg('Please select a framework.', mtError, [mbOK], 0);
+      Result := SelectFramework; // 再選択
+      Exit;
+    end;
+
+    if skyPatcherSelected then
+      Result := 'SkyPatcher'
+    else if rdfSelected then
+      Result := 'RDF'
+    else if recastSelected then
+      Result := 'Recast';
+
+  finally
+    opts.Free;
+    disableOpts.Free;
+  end;
 end;
 
 function Initialize: integer;
@@ -85,7 +145,6 @@ begin
   coChar              := '';
 
   callPreProcessor    := false;
-  useSkyPatcher       := false;
   useFormID           := false;
 
   disableAll          := false;
@@ -112,16 +171,19 @@ begin
     ) = mrYes then
     callPreProcessor := true;
 
-  if MessageDlg(
-    'Select which config file to generate:' + #13#10 +
-    'Yes = Generate for SkyPatcher' + #13#10 +
-    'No = Generate for RDF',
-    mtConfirmation, [mbYes, mbNo], 0
-    ) = mrYes then
-    useSkyPatcher := true;
+  // フレームワーク選択（チェックボックス方式、排他制御あり）
+  framework := SelectFramework;
+  if framework = '' then begin
+    AddMessage('Framework selection was canceled.');
+    Result := -1;
+    Exit;
+  end;
 
-  // SkyPatcherかRDFの利用に応じてコメントアウト文字を切り替え
-  if useSkyPatcher then
+  AddMessage('Selected framework: ' + framework);
+
+  // フレームワークの種類に応じてコメントアウト文字を切り替え
+  // TOML形式のRecastは '#' を使用、SkyPatcherは ';' を使用
+  if framework = 'SkyPatcher' then
     coChar := ';'
   else
     coChar := '#';
@@ -135,8 +197,10 @@ begin
   slCommentOut.Values['VoiceType'] := '';
   slCommentOut.Values['Outfit']    := '';
 
-  if useSkyPatcher then
+  if framework = 'SkyPatcher' then
     checkBoxCaption := 'Choose SkyPatcher Option'
+  else if framework = 'Recast' then
+    checkBoxCaption := 'Choose Recast Option'
   else
     checkBoxCaption := 'Choose RDF Option';
 
@@ -154,11 +218,20 @@ begin
     opts.Values['Output Name setting']                := 'False';
     opts.Values['Output VoiceType setting']           := 'False';
     opts.Values['Output Outfit setting']              := 'False';
-    if useSkyPatcher then begin
+
+    if framework = 'SkyPatcher' then begin
       opts.Values['Replace Visual Style'] := 'True';
       opts.Values['Replace Skin']         := 'True';
     end
+    else if framework = 'Recast' then begin
+      opts.Values['Replace Visual Style'] := 'True';
+      opts.Values['Replace Skin']         := 'True';
+      // RecastはRaceとOutfitに未対応のため無効化
+      disableOpts.Add('Output Race setting');
+      disableOpts.Add('Output Outfit setting');
+    end
     else begin
+      // RDFはSkyPatcher専用オプションを無効化
       disableOpts.Add('Replace Visual Style');
       disableOpts.Add('Replace Skin');
       disableOpts.Add('Output Race setting');
@@ -186,7 +259,7 @@ begin
     // 出力ファイルの記述をすべてコメントアウトするか
     disableAll := GetBoolSLValue(opts.Values['Disable the config file by default']);
 
-    // SkyPatcher利用時のオプション設定
+    // SkyPatcher、Recast利用時のオプション設定
     replaceVS       := GetBoolSLValue(opts.Values['Replace Visual Style']);    // 見た目を変更するか
     replaceSkin     := GetBoolSLValue(opts.Values['Replace Skin']);            // 肌を変更するか
 
@@ -196,6 +269,7 @@ begin
     outputName      := GetBoolSLValue(opts.Values['Output Name setting']);
     outputVoiceType := GetBoolSLValue(opts.Values['Output VoiceType setting']);
     outputOutfit    := GetBoolSLValue(opts.Values['Output Outfit setting']);
+
     // オプションの選択に応じて、設定行をコメントアウトする
     if disableAll then begin
       slCommentOut.Values['CopyVS']    := coChar;
@@ -207,15 +281,16 @@ begin
       slCommentOut.Values['Outfit']    := coChar;
     end
     else begin
-      if useSkyPatcher and not replaceVS then
+      // RDF以外（SkyPatcher・Recast）はReplace Visual Style/Skinトグルに連動
+      if (framework <> 'RDF') and not replaceVS then
         slCommentOut.Values['CopyVS'] := coChar;
 
       if not replaceSkin then
         slCommentOut.Values['Skin'] := coChar;
+    end;
 
       // outputXXXがOFFの項目は、Processで比較判定を行わないため、
       // ここで初期化する必要はない（Processで出力自体がスキップされる）
-    end;
 
   finally
     opts.Free;
@@ -366,7 +441,7 @@ begin
 
     trimedReplacerFormID := IntToHex(replacerFormID and  $FFFFFF, 1);
 
-    if useSkyPatcher then begin
+    if framework = 'SkyPatcher' then begin
       exportTargetID := targetFileName + '|' + trimedTargetFormID;
       exportReplacerID := replacerFileName + '|' + trimedReplacerFormID;
     end
@@ -406,10 +481,10 @@ begin
   exportName := replacerName;
 
   slExport.Add(coChar + GetElementEditValues(targetRecord, 'FULL'));
-  slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, useSkyPatcher));
+  slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
 
   // SkyPatcher利用時のみ出力する
-  if useSkyPatcher then begin
+  if framework = 'SkyPatcher' then begin
     slExport.Add(slCommentOut.Values['Skin'] + 'filterByNpcs=' + exportTargetID + ':skin=' + exportSkinID);
 
     // 各設定行は対応するoutputフラグがONの場合のみ出力
@@ -452,7 +527,7 @@ begin
   end;
 
   // 出力設定の決定
-  if useSkyPatcher then begin
+  if framework = 'SkyPatcher' then begin
     saveDir := DataPath + 'SkyPatcher RDF NPC Replacer Converter\SKSE\Plugins\SkyPatcher\npc\SkyPatcher NPC Replacer Converter\';
     filterString := 'Ini (*.ini)|*.ini';
     fileExtension := '.ini';

--- a/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
+++ b/SP_RDF NPC Replacer Converter - ConfigGenerator.pas
@@ -321,16 +321,21 @@ var
   replacerFlags, templateFlags, replacerRaceElement, replacerVoiceTypeElement, replacerOutfitElement, targetFlags, targetRaceElement, targetVoiceTypeElement, targetOutfitElement: IInterface;
   replacerRecord, targetRecord, replacerRaceRecord, replacerVoiceTypeRecord, replacerOutfitRecord, targetRaceRecord, targetVoiceTypeRecord, targetOutfitRecord: IwbMainRecord;
   replacerName, targetName: string;
-  replacerFormID, underscorePos: Cardinal;
-  originalTargetID, recordSignature, targetFormID, targetEditorID, replacerEditorID: string; // レコードID関連
-  trimedTargetFormID, trimedReplacerFormID, exportTargetID, exportReplacerID, wnamID, exportSkinID, exportRace, exportGender, exportName, exportVoiceType, exportOutfit: string; // SkyPatcher, Recast設定ファイルの記入用
-  useTraits, skipSkinThisRecord: boolean;
+  replacerFormIDNative, targetFormIDNative, underscorePos: Cardinal;
+  originalTargetID, recordSignature, targetFormIDHex, replacerFormIDHex, targetEditorID, replacerEditorID: string; // レコードID関連
+  localTargetFormID, localReplacerFormID,
+  trimedTargetFormID, trimedReplacerFormID,
+  paddedTargetFormID, paddedReplacerFormID: string; // FormIDを記入用に加工した文字列
+  exportTargetID, exportReplacerID, wnamID, exportSkinID, exportRace, exportGender,
+  exportName, exportVoiceType, exportOutfit: string; // SkyPatcher, Recast設定ファイルの記入用
+  useTraits: boolean;
 begin
-  targetFormID    := '';
+  targetFormIDHex    := '';
   targetEditorID  := '';
+  replacerFormIDHex    := '';
+  replacerEditorID  := '';
 
   recordSignature := 'NPC_';
-  skipSkinThisRecord := false;
 
 
   // NPCレコードでなければスキップ
@@ -348,7 +353,8 @@ begin
     replacerRecord := e;
 
   // リプレイサーNPCのForm ID, Editor IDを取得
-  replacerFormID := GetElementNativeValues(replacerRecord, 'Record Header\FormID');
+  replacerFormIDNative := GetElementNativeValues(replacerRecord, 'Record Header\FormID');
+  replacerFormIDHex := IntToHex64(replacerFormIDNative, 8);
    //AddMessage('Replacer Form ID: ' + IntToStr(replacerFormID));
    //AddMessage('Replacer Form ID: ' + IntToHex(replacerFormID, 8));
   replacerEditorID := GetElementEditValues(replacerRecord, 'EDID');
@@ -370,7 +376,9 @@ begin
   AddMessage('Target file name set to: ' + targetFileName);
 
   // ターゲットNPCのFormID,EditorIDを取得
-  targetFormID := IntToHex64(GetElementNativeValues(targetRecord, 'Record Header\FormID') and  $FFFFFF, 8);
+  //targetFormID := IntToHex64(GetElementNativeValues(targetRecord, 'Record Header\FormID'), 8);
+  targetFormIDNative := GetElementNativeValues(targetRecord, 'Record Header\FormID');
+  targetFormIDHex := IntToHex64(targetFormIDNative, 8);
     //AddMessage('Target Record Form ID: ' + targetFormID);
   targetEditorID := GetElementEditValues(targetRecord, 'EDID');
     //AddMessage('Target Record Editor ID: ' + targetEditorID);
@@ -454,16 +462,28 @@ begin
   end;
 
   // 出力ファイル用の配列操作
+  // FormIDを8桁の16進数文字列に変換し、プラグイン内で有効な値を取り出す
+  if  UpperCase(Copy(targetFormIDHex, 1, 2)) = 'FE' then
+    localTargetFormID := Copy(targetFormIDHex, 6, 8)
+  else
+    localTargetFormID := Copy(targetFormIDHex, 3, 8);
+
+  if  UpperCase(Copy(replacerFormIDHex, 1, 2)) = 'FE' then
+    localReplacerFormID := Copy(replacerFormIDHex, 6, 8)
+  else
+    localReplacerFormID := Copy(replacerFormIDHex, 3, 8);
+
   if useFormID then begin
-    // ゼロパディングしない形式のForm IDを設定、iniファイルへの記入はこちらを利用する
-    if  UpperCase(Copy(targetFormID, 1, 2)) = 'FE' then
-      trimedTargetFormID := Copy(targetFormID, 6, 8)
-    else
-      trimedTargetFormID := Copy(targetFormID, 3, 8);
-
-    trimedTargetFormID := RemoveLeadingZeros(trimedTargetFormID);
-
-    trimedReplacerFormID := IntToHex(replacerFormID and  $FFFFFF, 1);
+    if framework = 'Recast' then begin
+      // Recastはゼロパディングした形式のForm IDを設定、tomlファイルへの記入はこちらを利用する
+      paddedTargetFormID := PadLeftZero(localTargetFormID, 8);
+      paddedReplacerFormID := PadLeftZero(localReplacerFormID, 8);
+    end
+    else begin
+      // ゼロパディングしない形式のForm IDを設定、Recast以外の設定ファイルはこちらを利用する
+      trimedTargetFormID := RemoveLeadingZeros(localTargetFormID);
+      trimedReplacerFormID := RemoveLeadingZeros(localReplacerFormID);
+    end;
 
     if framework = 'SkyPatcher' then begin
       exportTargetID := targetFileName + '|' + trimedTargetFormID;
@@ -475,8 +495,8 @@ begin
     else if framework = 'Recast' then begin
       //exportTargetID := '0x' + targetFormID + '~' + targetFileName;
       //exportReplacerID := '0x' + replacerFormID + '~' + replacerFileName;
-      exportTargetID := trimedTargetFormID + '~' + targetFileName;
-      exportReplacerID := trimedReplacerFormID + '~' + replacerFileName;
+      exportTargetID := '0x' + paddedTargetFormID + '~' + targetFileName;
+      exportReplacerID := '0x' + paddedReplacerFormID + '~' + replacerFileName;
       exportRace  := IntToHex(FormID(replacerRaceRecord) and  $FFFFFF, 1) + '~' + GetFileName(replacerRaceRecord);
       exportVoiceType := IntToHex(FormID(replacerVoiceTypeRecord) and  $FFFFFF, 1) + '~' + GetFileName(replacerVoiceTypeRecord);
       exportOutfit := IntToHex(FormID(replacerOutfitRecord) and  $FFFFFF, 1) + '~' + GetFileName(replacerOutfitRecord);
@@ -485,7 +505,6 @@ begin
       exportTargetID := trimedTargetFormID + '~' + targetFileName;
       exportReplacerID := trimedReplacerFormID + '~' + replacerFileName;
     end;
-
   end
   else begin
     exportTargetID := targetEditorID;
@@ -506,9 +525,9 @@ begin
       exportSkinID := replacerFileName + '|' + wnamID;
   end
   else if framework = 'Recast' then begin
-    // RecastはWNAMにデフォルトボディを指定する方法がないため、未設定の場合は設定行を出力しない
+    // RecastはWNAMにデフォルトボディを指定する方法がないため、未設定の場合はコメントアウトする
     if wnamID = '0' then
-      skipSkinThisRecord := true
+      slCommentOut.Values['Skin'] := coChar
     else
       exportSkinID := wnamID + '~' + replacerFileName;
   end;
@@ -532,7 +551,7 @@ begin
 
   // 設定行の見出しとして、ターゲットNPCの名前、FormID、EditorIDを出力する
   slExport.Add(coChar + GetElementEditValues(targetRecord, 'FULL'));
-  slExport.Add(coChar + 'Form ID: ' + targetFormID + '  Editor ID: ' + targetEditorID);
+  slExport.Add(coChar + 'Form ID: ' + localTargetFormID + '  Editor ID: ' + targetEditorID);
 
   if framework = 'SkyPatcher' then begin
     slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
@@ -562,7 +581,7 @@ begin
     slExport.Add(slCommentOut.Values['CopyVS'] + GenerateVisualStyleString(exportTargetID, exportReplacerID, framework));
 
     // 各設定行は対応するoutputフラグがONの場合のみ出力
-    if outputSkin = true and not skipSkinThisRecord then
+    if outputSkin then
       slExport.Add(slCommentOut.Values['Skin'] + 'body = "' + exportSkinID + '"');
 
     // RaceはRecastでは未対応だが、将来的に対応する可能性があるため、コメントとして残しておく


### PR DESCRIPTION
NPCビジュアル配布フレームワーク、Recastへ対応
PreProseccorは編集なし

- ビジュアル配布フレームワークを選択するチェックリストフォームを追加
- 共通スクリプトのRemoveLeadingZeros関数を修正、PadLeftZero関数を追加
- 設定ファイルの出力を改善、ターゲットNPCの名前だけでなく、From ID,Editor IDを出力するようにした
- Form ID関連の処理の不具合を修正